### PR TITLE
chore: return uri when already prefixed

### DIFF
--- a/packages/dgt-components/lib/components/authentication/authenticate.services.spec.ts
+++ b/packages/dgt-components/lib/components/authentication/authenticate.services.spec.ts
@@ -60,7 +60,9 @@ describe('AuthenticateServices', () => {
 
     it('should return given uri when prefix was given and uri is valid', async () => {
 
-      event.webId = 'https://example.com/profile/card#me';
+      event.webId = 'http://example.com/profile/card#me';
+
+      (utils as any).addProtocolPrefix = jest.fn().mockResolvedValueOnce('http://example.com/profile/card#me');
 
       const response = checkWebId(context, event);
 
@@ -70,6 +72,7 @@ describe('AuthenticateServices', () => {
 
       expect(result.webId).toBe(event.webId);
       expect(result.validationResults).toHaveLength(0);
+      expect((utils as any).addProtocolPrefix).toHaveBeenCalledTimes(1);
 
     });
 

--- a/packages/dgt-components/lib/components/authentication/authenticate.services.ts
+++ b/packages/dgt-components/lib/components/authentication/authenticate.services.ts
@@ -16,7 +16,7 @@ Promise<{ webId: string; validationResults: string[] }> => {
 
   try {
 
-    webId = await addProtocolPrefix(event.webId);
+    webId = await addProtocolPrefix(webId);
     validationResults = await context.webIdValidator(webId);
 
   } catch(e){

--- a/packages/dgt-components/lib/components/authentication/authenticate.services.ts
+++ b/packages/dgt-components/lib/components/authentication/authenticate.services.ts
@@ -16,7 +16,7 @@ Promise<{ webId: string; validationResults: string[] }> => {
 
   try {
 
-    webId = event.webId.match(/^https?:\/\/.*$/) ? event.webId : await addProtocolPrefix(event.webId);
+    webId = await addProtocolPrefix(event.webId);
     validationResults = await context.webIdValidator(webId);
 
   } catch(e){

--- a/packages/dgt-components/package.json
+++ b/packages/dgt-components/package.json
@@ -93,7 +93,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 76.69,
+        "branches": 76.33,
         "functions": 74.01,
         "lines": 88.97,
         "statements": 89.22

--- a/packages/dgt-utils/lib/utils/add-protocol-prefix.spec.ts
+++ b/packages/dgt-utils/lib/utils/add-protocol-prefix.spec.ts
@@ -12,6 +12,14 @@ const MOCK_URI = 'example.com';
 
 describe('addProtocolPrefix()', () => {
 
+  it('should return uri when uri is complete', async () => {
+
+    const response = addProtocolPrefix('https://' + MOCK_URI);
+
+    await expect(response).resolves.toBe('https://' + MOCK_URI);
+
+  });
+
   it('should return uri with https when https is working', async () => {
 
     ((crossFetch as unknown) as jest.MockInstance<any, any>).mockResolvedValueOnce(JSON.stringify({ uri: 'https://' + MOCK_URI }));

--- a/packages/dgt-utils/lib/utils/add-protocol-prefix.spec.ts
+++ b/packages/dgt-utils/lib/utils/add-protocol-prefix.spec.ts
@@ -8,47 +8,41 @@ jest.mock('cross-fetch', () => ({
   default: jest.fn(),
 }));
 
-const MOCK_URI = 'example.com';
+const nonPrefixedUri = 'example.com';
+const httpsUri = `https://${nonPrefixedUri}`;
+const httpUri = `http://${nonPrefixedUri}`;
 
 describe('addProtocolPrefix()', () => {
 
-  it('should return uri when uri is complete', async () => {
+  it('should return uri when uri already is prefixed', async () => {
 
-    const response = addProtocolPrefix('https://' + MOCK_URI);
-
-    await expect(response).resolves.toBe('https://' + MOCK_URI);
-
-  });
-
-  it('should return uri with https when https is working', async () => {
-
-    ((crossFetch as unknown) as jest.MockInstance<any, any>).mockResolvedValueOnce(JSON.stringify({ uri: 'https://' + MOCK_URI }));
-
-    const response = addProtocolPrefix(MOCK_URI);
-
-    await expect(response).resolves.toBe('https://' + MOCK_URI);
+    await expect(addProtocolPrefix(httpsUri)).resolves.toBe(httpsUri);
+    await expect(addProtocolPrefix(httpUri)).resolves.toBe(httpUri);
 
   });
 
-  it('should return uri with http when https is not working', async () => {
+  it('should return uri prefixed with https if HEAD request succeeds', async () => {
 
-    ((crossFetch as unknown) as jest.MockInstance<any, any>).mockRejectedValueOnce('addr_not_found');
-    ((crossFetch as unknown) as jest.MockInstance<any, any>).mockResolvedValueOnce(JSON.stringify({ uri: 'http://' + MOCK_URI }));
+    ((crossFetch as unknown) as jest.MockInstance<any, any>).mockResolvedValueOnce('');
 
-    const response = addProtocolPrefix(MOCK_URI);
+    await expect(addProtocolPrefix(nonPrefixedUri)).resolves.toBe(httpsUri);
 
-    await expect(response).resolves.toBe('http://' + MOCK_URI);
+  });
+
+  it('should return uri prefixed with http if HEAD request succeeds', async () => {
+
+    ((crossFetch as unknown) as jest.MockInstance<any, any>).mockRejectedValueOnce('');
+    ((crossFetch as unknown) as jest.MockInstance<any, any>).mockResolvedValueOnce('');
+
+    await expect(addProtocolPrefix(nonPrefixedUri)).resolves.toBe(httpUri);
 
   });
 
   it('should throw when both http and https uris cannot be fetched', async () => {
 
-    ((crossFetch as unknown) as jest.MockInstance<any, any>).mockRejectedValueOnce('addr_not_found');
-    ((crossFetch as unknown) as jest.MockInstance<any, any>).mockRejectedValueOnce('addr_not_found');
+    ((crossFetch as unknown) as jest.MockInstance<any, any>).mockRejectedValue('');
 
-    const response = addProtocolPrefix(MOCK_URI);
-
-    await expect(response).rejects.toThrow(`Could not add protocol prefix to ${MOCK_URI}`);
+    await expect(addProtocolPrefix(nonPrefixedUri)).rejects.toThrow(`Could not add protocol prefix to ${nonPrefixedUri}`);
 
   });
 

--- a/packages/dgt-utils/lib/utils/add-protocol-prefix.ts
+++ b/packages/dgt-utils/lib/utils/add-protocol-prefix.ts
@@ -10,23 +10,21 @@ import fetch from 'cross-fetch';
  */
 export const addProtocolPrefix = async (uri: string): Promise<string> => {
 
-  try {
+  if (uri.match('^https?://')) return uri ;
 
-    if (uri.match('^https?://'))  return uri ;
+  try {
 
     try {
 
       const httpsUri = `https://${uri}`;
-      await fetch(httpsUri, { method: 'HEAD' });
 
-      return httpsUri;
+      return await fetch(httpsUri, { method: 'HEAD' }).then(() => httpsUri);
 
     } catch(e) {
 
       const httpUri = `http://${uri}`;
-      await fetch(httpUri, { method: 'HEAD' });
 
-      return httpUri;
+      return await fetch(httpUri, { method: 'HEAD' }).then(() => httpUri);
 
     }
 

--- a/packages/dgt-utils/lib/utils/add-protocol-prefix.ts
+++ b/packages/dgt-utils/lib/utils/add-protocol-prefix.ts
@@ -12,6 +12,8 @@ export const addProtocolPrefix = async (uri: string): Promise<string> => {
 
   try {
 
+    if (uri.match('^https?://'))  return uri ;
+
     try {
 
       const httpsUri = `https://${uri}`;
@@ -35,3 +37,4 @@ export const addProtocolPrefix = async (uri: string): Promise<string> => {
   }
 
 };
+

--- a/packages/dgt-utils/package.json
+++ b/packages/dgt-utils/package.json
@@ -84,10 +84,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 56.33,
-        "functions": 47.56,
-        "lines": 61.96,
-        "statements": 62.26
+        "branches": 58.57,
+        "functions": 50.66,
+        "lines": 63.63,
+        "statements": 63.88
       }
     },
     "coveragePathIgnorePatterns": [

--- a/packages/dgt-utils/package.json
+++ b/packages/dgt-utils/package.json
@@ -85,8 +85,8 @@
     "coverageThreshold": {
       "global": {
         "branches": 58.57,
-        "functions": 50.66,
-        "lines": 63.63,
+        "functions": 51.94,
+        "lines": 63.3,
         "statements": 63.88
       }
     },


### PR DESCRIPTION
FYI: in authenticate.service.ts there is a check for http(s) and if it's not prefixed it invokes addProtocolPrefix. Should this be deleted or ?